### PR TITLE
Optimize S3 read writes on transcription flow

### DIFF
--- a/server/lambdas/check_input_file_type.py
+++ b/server/lambdas/check_input_file_type.py
@@ -68,7 +68,7 @@ def handler(event, context):
         event['input_file'] = file_name_without_extn
         event['output_s3_key'] = output_key
         event['audio_chunks_s3_key'] = output_key + "/chunks/"
-        event['txt_chunks_s3_key'] = output_key + "/txt_chunks/"
+        event['txt_chunks_s3_key'] = output_key + "/txt_chunks/data.json.gz"
         event['diarization_file'] = file_name_without_extn + '.diarization.txt'
         event['output_file'] = file_name_without_extn + ".json"
         event['original_transcription_file'] = chat_transcript_file_path


### PR DESCRIPTION
*Description of changes:*
In the existing flow, for each voice chunk we store the text in individual s3 files, spend time to upload inside the loop.
Similarly we download the file from s3 on each iteration in lambda while processing.
If on case any error occurs during transcibe flow, we are anyway restarting from that step.

Hence storing the information of each chunk in formatted data structure inside one single file which is compressed to gzip and uploaded to S3. This provides below advantages
- Remove I/O call to/from S3 inside the loop
- compressed json helps to reduce final file size & reduces network latency required for upload & download
- Since the output is now structured, we can add additional metadata from the ML model to be utilized by client if required.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
